### PR TITLE
Increase unit and integration testing

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,7 +64,16 @@ These sequences were run and validated in a Windows PowerShell environment in th
 
    `go test ./...`
 
-   Observed results: `ok what-to-watch/shows 3.659s` and `ok what-to-watch/cmd/http` (tests pass locally). The `data`, `db`, and `cli` packages have no tests. HTTP handler tests use table-driven approach with mocked `Handler` interface. Running `go test ./...` in CI is the expected validation step.
+   HTTP handler tests use table-driven approach with mocked `Handler` interface. The suite also includes db unit tests, handler integration tests, CLI formatting and flow tests, HTTP route integration tests, and main dispatch tests. Running `go test ./...` in CI is the expected validation step.
+
+   To check package coverage:
+
+   `go test ./... -cover`
+
+   For a detailed local coverage report:
+
+   `go test ./... -coverprofile=coverage.out`
+   `go tool cover -func=coverage.out`
 
 7) Lint / formatting:
 
@@ -103,7 +112,7 @@ Quick validation guidance for the agent making changes
 - Always run locally before opening a PR: `go build ./...` then `go test ./...`.
 - Ensure your Go tool version matches CI (1.25.4). If you cannot install that version locally, run CI-oriented checks in a container or use `actions/setup-go` locally in a disposable runner.
 - If the change touches file I/O, double-check `db.getFullPath` semantics: built binaries and `go run` resolve files differently.
-- Unit tests live in `shows/` and `cmd/http/` — read `shows/shows_test.go` for business logic tests and `cmd/http/http_test.go` for HTTP handler tests as models.
+- Unit and integration tests live in `shows/`, `db/`, `handlers/`, `cmd/cli/`, `cmd/http/`, and the main package. Read `shows/shows_test.go` for business logic tests, `cmd/http/http_test.go` for HTTP handler and route tests, and `handlers/handlers_test.go` for temp-fixture integration tests as models.
 
 Where to search if instructions appear incomplete
 
@@ -125,7 +134,7 @@ Short content snapshot (high-priority snippets)
 - `data/data.go`: `Show` struct (with episode tracking) and `Film` struct (simple name/genre/provider).
 - `shows/shows.go`: contains `GetCurrentlyWatching`, `MarkEpisodeWatched`, `GetUniqueGenres`, and `GetUnwatchedShowsByGenre` business logic (tests in `shows/shows_test.go`).
 - `cmd/http/http.go`: defines `Handler` interface for dependency injection; `defaultHandler` implements it by calling `handlers` package functions.
-- `cmd/http/http_test.go`: table-driven tests for all HTTP handlers (`TestHandleGetShows`, `TestHandleMarkShowWatched`, `TestHandleGetFilms`, `TestHandleGetGenres`, `TestHandleGetShowsByGenre`, `TestHandleHealth`) with `mockHandler` providing test stubs.
+- `cmd/http/http_test.go`: table-driven tests for all HTTP handlers plus route-level integration tests with `mockHandler` providing test stubs.
 
 If anything in this file is inconsistent with the repo state, run `git status` and search the few files listed above before making changes.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Common Commands (PowerShell)
 go version
 go build ./...
 go test ./...
+go test ./... -cover
 go run .              # CLI mode (default)
 go run . -mode=http   # HTTP mode on default port 8080
 ```
@@ -56,6 +57,7 @@ Testing & Validation
 ```sh
 go vet ./...
 go test ./...
+go test ./... -cover
 ```
 
 Committing & PRs

--- a/README.md
+++ b/README.md
@@ -97,3 +97,24 @@ Both modes use the same underlying business logic, ensuring consistency across i
 1. Run `go build`
 2. Run `go install`
 3. `what-to-watch` should be available to run from any directory
+
+## Testing
+
+Run the full test suite:
+
+```bash
+go test ./...
+```
+
+Check package coverage:
+
+```bash
+go test ./... -cover
+```
+
+For a detailed coverage report:
+
+```bash
+go test ./... -coverprofile=coverage.out
+go tool cover -func=coverage.out
+```

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -10,6 +10,14 @@ import (
 	"what-to-watch/handlers"
 )
 
+var (
+	getCurrentlyWatchingShows = handlers.GetCurrentlyWatchingShows
+	markShowWatched           = handlers.MarkShowWatched
+	getAllFilms               = handlers.GetAllFilms
+	getAvailableGenres        = handlers.GetAvailableGenres
+	getUnwatchedShowsByGenre  = handlers.GetUnwatchedShowsByGenre
+)
+
 // Run starts the interactive CLI mode
 func Run() {
 	reader := bufio.NewReader(os.Stdin)
@@ -37,7 +45,7 @@ func Run() {
 }
 
 func viewShows(reader *bufio.Reader) {
-	shows, err := handlers.GetCurrentlyWatchingShows()
+	shows, err := getCurrentlyWatchingShows()
 	if err != nil {
 		fmt.Printf("Error: %s\n", err)
 		return
@@ -60,7 +68,7 @@ func viewShows(reader *bufio.Reader) {
 		return
 	}
 
-	isCompleted, err := handlers.MarkShowWatched(idx)
+	isCompleted, err := markShowWatched(idx)
 	if err != nil {
 		fmt.Printf("Error: %s\n", err)
 		return
@@ -74,7 +82,7 @@ func viewShows(reader *bufio.Reader) {
 }
 
 func viewFilms() {
-	films, err := handlers.GetAllFilms()
+	films, err := getAllFilms()
 	if err != nil {
 		fmt.Printf("Error: %s\n", err)
 		return
@@ -85,7 +93,7 @@ func viewFilms() {
 
 func viewShowsByGenre(reader *bufio.Reader) {
 	// Get available genres
-	genres, err := handlers.GetAvailableGenres()
+	genres, err := getAvailableGenres()
 	if err != nil {
 		fmt.Printf("Error: %s\n", err)
 		return
@@ -120,7 +128,7 @@ func viewShowsByGenre(reader *bufio.Reader) {
 	selectedGenre := genres[idx-1]
 
 	// Get shows for selected genre
-	shows, err := handlers.GetUnwatchedShowsByGenre(selectedGenre)
+	shows, err := getUnwatchedShowsByGenre(selectedGenre)
 	if err != nil {
 		fmt.Printf("Error: %s\n", err)
 		return

--- a/cmd/cli/cli_test.go
+++ b/cmd/cli/cli_test.go
@@ -1,0 +1,317 @@
+package cli
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"what-to-watch/data"
+)
+
+func TestViewShowsCancel(t *testing.T) {
+	restore := stubCLIHandlers()
+	t.Cleanup(restore)
+
+	getCurrentlyWatchingShows = func() ([]data.Show, error) {
+		return []data.Show{{Name: "Slow Horses", Genre: "Drama", Provider: "Apple TV+", Series: "1", Episode: "5"}}, nil
+	}
+	markCalled := false
+	markShowWatched = func(int) (bool, error) {
+		markCalled = true
+		return false, nil
+	}
+
+	output := captureOutput(t, func() {
+		viewShows(bufio.NewReader(strings.NewReader("0\n")))
+	})
+
+	if markCalled {
+		t.Fatalf("expected MarkShowWatched not to be called")
+	}
+	assertContains(t, output, "Slow Horses")
+	assertContains(t, output, "No changes made.")
+}
+
+func TestViewShowsRejectsNonNumericInput(t *testing.T) {
+	restore := stubCLIHandlers()
+	t.Cleanup(restore)
+
+	getCurrentlyWatchingShows = func() ([]data.Show, error) {
+		return []data.Show{{Name: "Severance", Genre: "Sci-Fi", Provider: "Apple TV+", Series: "1", Episode: "3"}}, nil
+	}
+
+	output := captureOutput(t, func() {
+		viewShows(bufio.NewReader(strings.NewReader("abc\n")))
+	})
+
+	assertContains(t, output, "Invalid input: abc")
+}
+
+func TestViewShowsMarksSelectedShowWatched(t *testing.T) {
+	tests := []struct {
+		name       string
+		completed  bool
+		wantOutput string
+	}{
+		{name: "not completed", completed: false, wantOutput: "Show 2 marked as watched."},
+		{name: "completed", completed: true, wantOutput: "Show 2 marked as watched and completed!"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			restore := stubCLIHandlers()
+			t.Cleanup(restore)
+
+			getCurrentlyWatchingShows = func() ([]data.Show, error) {
+				return []data.Show{{Name: "Andor", Genre: "Sci-Fi", Provider: "Disney+", Series: "2", Episode: "4"}}, nil
+			}
+			var gotIndex int
+			markShowWatched = func(idx int) (bool, error) {
+				gotIndex = idx
+				return tt.completed, nil
+			}
+
+			output := captureOutput(t, func() {
+				viewShows(bufio.NewReader(strings.NewReader("2\n")))
+			})
+
+			if gotIndex != 2 {
+				t.Fatalf("expected MarkShowWatched index 2, got %d", gotIndex)
+			}
+			assertContains(t, output, tt.wantOutput)
+		})
+	}
+}
+
+func TestViewShowsPrintsHandlerErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func()
+		input string
+	}{
+		{
+			name: "get shows error",
+			setup: func() {
+				getCurrentlyWatchingShows = func() ([]data.Show, error) {
+					return nil, errors.New("cannot read shows")
+				}
+			},
+		},
+		{
+			name: "mark watched error",
+			setup: func() {
+				getCurrentlyWatchingShows = func() ([]data.Show, error) {
+					return []data.Show{{Name: "Andor", Genre: "Sci-Fi", Provider: "Disney+", Series: "2", Episode: "4"}}, nil
+				}
+				markShowWatched = func(int) (bool, error) {
+					return false, errors.New("cannot save shows")
+				}
+			},
+			input: "1\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			restore := stubCLIHandlers()
+			t.Cleanup(restore)
+			tt.setup()
+
+			output := captureOutput(t, func() {
+				viewShows(bufio.NewReader(strings.NewReader(tt.input)))
+			})
+
+			assertContains(t, output, "Error:")
+		})
+	}
+}
+
+func TestViewFilmsDisplaysFilms(t *testing.T) {
+	restore := stubCLIHandlers()
+	t.Cleanup(restore)
+
+	getAllFilms = func() ([]data.Film, error) {
+		return []data.Film{{Name: "Arrival", Genre: "Sci-Fi", Provider: "Netflix"}}, nil
+	}
+
+	output := captureOutput(t, viewFilms)
+
+	assertContains(t, output, "Arrival")
+	assertContains(t, output, "Sci-Fi")
+}
+
+func TestViewFilmsPrintsHandlerError(t *testing.T) {
+	restore := stubCLIHandlers()
+	t.Cleanup(restore)
+
+	getAllFilms = func() ([]data.Film, error) {
+		return nil, errors.New("cannot read films")
+	}
+
+	output := captureOutput(t, viewFilms)
+
+	assertContains(t, output, "Error: cannot read films")
+}
+
+func TestViewShowsByGenreDisplaysSelectedGenre(t *testing.T) {
+	restore := stubCLIHandlers()
+	t.Cleanup(restore)
+
+	getAvailableGenres = func() ([]string, error) {
+		return []string{"Drama", "Comedy"}, nil
+	}
+	var gotGenre string
+	getUnwatchedShowsByGenre = func(genre string) ([]data.Show, error) {
+		gotGenre = genre
+		return []data.Show{{Name: "Unstarted Comedy", Provider: "Netflix"}}, nil
+	}
+
+	output := captureOutput(t, func() {
+		viewShowsByGenre(bufio.NewReader(strings.NewReader("2\n")))
+	})
+
+	if gotGenre != "Comedy" {
+		t.Fatalf("expected selected genre Comedy, got %q", gotGenre)
+	}
+	assertContains(t, output, "Available genres:")
+	assertContains(t, output, "Unwatched shows in genre 'Comedy':")
+	assertContains(t, output, "Unstarted Comedy")
+}
+
+func TestViewShowsByGenreHandlesCancelInvalidAndEmptyGenres(t *testing.T) {
+	tests := []struct {
+		name       string
+		genres     []string
+		input      string
+		wantOutput string
+	}{
+		{name: "empty genres", genres: nil, wantOutput: "No genres available."},
+		{name: "cancel", genres: []string{"Drama"}, input: "0\n", wantOutput: "No selection made."},
+		{name: "invalid text", genres: []string{"Drama"}, input: "abc\n", wantOutput: "Invalid input: abc"},
+		{name: "out of range", genres: []string{"Drama"}, input: "2\n", wantOutput: "Invalid input: 2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			restore := stubCLIHandlers()
+			t.Cleanup(restore)
+
+			getAvailableGenres = func() ([]string, error) {
+				return tt.genres, nil
+			}
+
+			output := captureOutput(t, func() {
+				viewShowsByGenre(bufio.NewReader(strings.NewReader(tt.input)))
+			})
+
+			assertContains(t, output, tt.wantOutput)
+		})
+	}
+}
+
+func TestViewShowsByGenrePrintsHandlerErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func()
+		input string
+		want  string
+	}{
+		{
+			name: "get genres error",
+			setup: func() {
+				getAvailableGenres = func() ([]string, error) {
+					return nil, errors.New("cannot read genres")
+				}
+			},
+			want: "Error: cannot read genres",
+		},
+		{
+			name: "get shows by genre error",
+			setup: func() {
+				getAvailableGenres = func() ([]string, error) {
+					return []string{"Drama"}, nil
+				}
+				getUnwatchedShowsByGenre = func(string) ([]data.Show, error) {
+					return nil, errors.New("cannot read shows")
+				}
+			},
+			input: "1\n",
+			want:  "Error: cannot read shows",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			restore := stubCLIHandlers()
+			t.Cleanup(restore)
+			tt.setup()
+
+			output := captureOutput(t, func() {
+				viewShowsByGenre(bufio.NewReader(strings.NewReader(tt.input)))
+			})
+
+			assertContains(t, output, tt.want)
+		})
+	}
+}
+
+func stubCLIHandlers() func() {
+	originalGetCurrentlyWatchingShows := getCurrentlyWatchingShows
+	originalMarkShowWatched := markShowWatched
+	originalGetAllFilms := getAllFilms
+	originalGetAvailableGenres := getAvailableGenres
+	originalGetUnwatchedShowsByGenre := getUnwatchedShowsByGenre
+
+	getCurrentlyWatchingShows = func() ([]data.Show, error) { return nil, nil }
+	markShowWatched = func(int) (bool, error) { return false, nil }
+	getAllFilms = func() ([]data.Film, error) { return nil, nil }
+	getAvailableGenres = func() ([]string, error) { return nil, nil }
+	getUnwatchedShowsByGenre = func(string) ([]data.Show, error) { return nil, nil }
+
+	return func() {
+		getCurrentlyWatchingShows = originalGetCurrentlyWatchingShows
+		markShowWatched = originalMarkShowWatched
+		getAllFilms = originalGetAllFilms
+		getAvailableGenres = originalGetAvailableGenres
+		getUnwatchedShowsByGenre = originalGetUnwatchedShowsByGenre
+	}
+}
+
+func captureOutput(t *testing.T, fn func()) string {
+	t.Helper()
+
+	originalStdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("creating pipe: %v", err)
+	}
+
+	os.Stdout = writer
+	fn()
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("closing writer: %v", err)
+	}
+	os.Stdout = originalStdout
+
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("closing reader: %v", err)
+	}
+
+	return string(output)
+}
+
+func assertContains(t *testing.T, got, want string) {
+	t.Helper()
+
+	if !strings.Contains(got, want) {
+		t.Fatalf("expected output to contain %q, got %q", want, got)
+	}
+}

--- a/cmd/cli/format_test.go
+++ b/cmd/cli/format_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"testing"
+
+	"what-to-watch/data"
+)
+
+func TestFormatShowsTable(t *testing.T) {
+	shows := []data.Show{
+		{Name: "A", Genre: "Drama", Provider: "BBC", Series: "1", Episode: "2"},
+		{Name: "Long Show", Genre: "Comedy", Provider: "Netflix", Series: "12", Episode: "10"},
+	}
+
+	expected := "" +
+		"Index  Name       Genre   Provider  Series  Episode\n" +
+		"-----  ---------  ------  --------  ------  -------\n" +
+		"1      A          Drama   BBC       1       2      \n" +
+		"2      Long Show  Comedy  Netflix   12      10     \n"
+
+	if got := formatShowsTable(shows); got != expected {
+		t.Fatalf("expected:\n%q\ngot:\n%q", expected, got)
+	}
+}
+
+func TestFormatShowsTableEmpty(t *testing.T) {
+	expected := "No shows currently being watched.\n"
+
+	if got := formatShowsTable(nil); got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestFormatShowsByGenreTable(t *testing.T) {
+	shows := []data.Show{
+		{Name: "Long Drama", Provider: "Netflix"},
+		{Name: "A", Provider: "BBC"},
+	}
+
+	expected := "" +
+		"Index  Name        Provider\n" +
+		"-----  ----------  --------\n" +
+		"1      Long Drama  Netflix \n" +
+		"2      A           BBC     \n"
+
+	if got := formatShowsByGenreTable(shows); got != expected {
+		t.Fatalf("expected:\n%q\ngot:\n%q", expected, got)
+	}
+}
+
+func TestFormatShowsByGenreTableEmpty(t *testing.T) {
+	expected := "No unwatched shows in this genre.\n"
+
+	if got := formatShowsByGenreTable(nil); got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestFormatFilmsTable(t *testing.T) {
+	films := []data.Film{
+		{Name: "Arrival", Genre: "Sci-Fi", Provider: "Netflix"},
+		{Name: "Up", Genre: "Family", Provider: "Disney+"},
+	}
+
+	expected := "" +
+		"Index  Name     Genre   Provider\n" +
+		"-----  -------  ------  --------\n" +
+		"1      Arrival  Sci-Fi  Netflix \n" +
+		"2      Up       Family  Disney+ \n"
+
+	if got := formatFilmsTable(films); got != expected {
+		t.Fatalf("expected:\n%q\ngot:\n%q", expected, got)
+	}
+}
+
+func TestFormatFilmsTableEmpty(t *testing.T) {
+	expected := "No films found.\n"
+
+	if got := formatFilmsTable(nil); got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}

--- a/cmd/http/http.go
+++ b/cmd/http/http.go
@@ -65,25 +65,30 @@ func NewServerWithHandler(port int, handler Handler) *Server {
 
 // Start begins listening for HTTP requests
 func (s *Server) Start() error {
-	http.HandleFunc("/shows", func(w http.ResponseWriter, r *http.Request) {
+	addr := fmt.Sprintf(":%d", s.port)
+	fmt.Printf("HTTP server listening on port %d\n", s.port)
+	return http.ListenAndServe(addr, s.routes())
+}
+
+func (s *Server) routes() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/shows", func(w http.ResponseWriter, r *http.Request) {
 		s.handleGetShows(w, r)
 	})
-	http.HandleFunc("/shows/watch", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/shows/watch", func(w http.ResponseWriter, r *http.Request) {
 		s.handleMarkShowWatched(w, r)
 	})
-	http.HandleFunc("/films", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/films", func(w http.ResponseWriter, r *http.Request) {
 		s.handleGetFilms(w, r)
 	})
-	http.HandleFunc("/genres", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/genres", func(w http.ResponseWriter, r *http.Request) {
 		s.handleGetGenres(w, r)
 	})
-	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		s.handleHealth(w, r)
 	})
 
-	addr := fmt.Sprintf(":%d", s.port)
-	fmt.Printf("HTTP server listening on port %d\n", s.port)
-	return http.ListenAndServe(addr, nil)
+	return mux
 }
 
 func (s *Server) handleGetShows(w http.ResponseWriter, r *http.Request) {

--- a/cmd/http/http_test.go
+++ b/cmd/http/http_test.go
@@ -496,3 +496,197 @@ func TestHandleHealth(t *testing.T) {
 		})
 	}
 }
+
+func TestServerRoutes(t *testing.T) {
+	var watchedIndex int
+	mock := &mockHandler{
+		getShowsFunc: func() ([]data.Show, error) {
+			return []data.Show{{Name: "Slow Horses", Genre: "Drama", Provider: "Apple TV+"}}, nil
+		},
+		getUnwatchedByGenreFunc: func(genre string) ([]data.Show, error) {
+			return []data.Show{{Name: "Unstarted " + genre, Genre: genre, Provider: "Netflix"}}, nil
+		},
+		markShowWatchedFunc: func(idx int) (bool, error) {
+			watchedIndex = idx
+			return true, nil
+		},
+		getFilmsFunc: func() ([]data.Film, error) {
+			return []data.Film{{Name: "Arrival", Genre: "Sci-Fi", Provider: "Netflix"}}, nil
+		},
+		getGenresFunc: func() ([]string, error) {
+			return []string{"Drama", "Comedy"}, nil
+		},
+	}
+
+	server := NewServerWithHandler(8080, mock)
+	testServer := httptest.NewServer(server.routes())
+	defer testServer.Close()
+
+	t.Run("GET /shows", func(t *testing.T) {
+		resp, body := getRoute(t, testServer.URL+"/shows")
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+
+		var shows []data.Show
+		unmarshalBody(t, body, &shows)
+		if len(shows) != 1 || shows[0].Name != "Slow Horses" {
+			t.Fatalf("unexpected shows response: %+v", shows)
+		}
+	})
+
+	t.Run("GET /shows with genre", func(t *testing.T) {
+		resp, body := getRoute(t, testServer.URL+"/shows?genre=Drama")
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+
+		var shows []data.Show
+		unmarshalBody(t, body, &shows)
+		if len(shows) != 1 || shows[0].Name != "Unstarted Drama" {
+			t.Fatalf("unexpected genre response: %+v", shows)
+		}
+	})
+
+	t.Run("POST /shows/watch", func(t *testing.T) {
+		resp, body := postRoute(t, testServer.URL+"/shows/watch?index=3")
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+		if watchedIndex != 3 {
+			t.Fatalf("expected watched index 3, got %d", watchedIndex)
+		}
+
+		var completed bool
+		unmarshalBody(t, body, &completed)
+		if !completed {
+			t.Fatalf("expected completed response to be true")
+		}
+	})
+
+	t.Run("GET /films", func(t *testing.T) {
+		resp, body := getRoute(t, testServer.URL+"/films")
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+
+		var films []data.Film
+		unmarshalBody(t, body, &films)
+		if len(films) != 1 || films[0].Name != "Arrival" {
+			t.Fatalf("unexpected films response: %+v", films)
+		}
+	})
+
+	t.Run("GET /genres", func(t *testing.T) {
+		resp, body := getRoute(t, testServer.URL+"/genres")
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+
+		var genres []string
+		unmarshalBody(t, body, &genres)
+		if len(genres) != 2 || genres[0] != "Drama" || genres[1] != "Comedy" {
+			t.Fatalf("unexpected genres response: %+v", genres)
+		}
+	})
+
+	t.Run("GET /health", func(t *testing.T) {
+		resp, body := getRoute(t, testServer.URL+"/health")
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+		if got := bytes.TrimSpace(body); !bytes.Equal(got, []byte("null")) {
+			t.Fatalf("expected health body null, got %q", string(got))
+		}
+	})
+}
+
+func TestServerRoutesMethodAndNotFoundResponses(t *testing.T) {
+	mock := &mockHandler{}
+	server := NewServerWithHandler(8080, mock)
+	testServer := httptest.NewServer(server.routes())
+	defer testServer.Close()
+
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		wantStatus int
+	}{
+		{name: "unsupported route method", method: http.MethodPost, path: "/shows", wantStatus: http.StatusMethodNotAllowed},
+		{name: "unknown route", method: http.MethodGet, path: "/missing", wantStatus: http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(tt.method, testServer.URL+tt.path, nil)
+			if err != nil {
+				t.Fatalf("creating request: %v", err)
+			}
+
+			resp, err := testServer.Client().Do(req)
+			if err != nil {
+				t.Fatalf("sending request: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d", tt.wantStatus, resp.StatusCode)
+			}
+		})
+	}
+}
+
+func getRoute(t *testing.T, url string) (*http.Response, []byte) {
+	t.Helper()
+
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		resp.Body.Close()
+		t.Fatalf("reading body: %v", err)
+	}
+
+	return resp, body
+}
+
+func postRoute(t *testing.T, url string) (*http.Response, []byte) {
+	t.Helper()
+
+	resp, err := http.Post(url, "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		resp.Body.Close()
+		t.Fatalf("reading body: %v", err)
+	}
+
+	return resp, body
+}
+
+func unmarshalBody(t *testing.T, body []byte, v interface{}) {
+	t.Helper()
+
+	if err := json.Unmarshal(body, v); err != nil {
+		t.Fatalf("unmarshaling %q: %v", string(body), err)
+	}
+}

--- a/db/db.go
+++ b/db/db.go
@@ -12,6 +12,16 @@ import (
 
 var fullPathResolver = getFullPath
 
+// SetFullPathResolverForTest replaces the data file path resolver and returns
+// a restore function. It is intended for tests that need isolated fixture files.
+func SetFullPathResolverForTest(resolver func(string) string) func() {
+	originalResolver := fullPathResolver
+	fullPathResolver = resolver
+	return func() {
+		fullPathResolver = originalResolver
+	}
+}
+
 // ReadShows reads the shows from the shows.json file and returns a slice of Show structs.
 func ReadShows() ([]data.Show, error) {
 	raw, err := readFile("shows.json")

--- a/db/db.go
+++ b/db/db.go
@@ -10,6 +10,8 @@ import (
 	"what-to-watch/data"
 )
 
+var fullPathResolver = getFullPath
+
 // ReadShows reads the shows from the shows.json file and returns a slice of Show structs.
 func ReadShows() ([]data.Show, error) {
 	raw, err := readFile("shows.json")
@@ -64,7 +66,7 @@ func WriteCurrentShows(shows []data.Show) error {
 		return err
 	}
 
-	fullPath := getFullPath("currentShows.json")
+	fullPath := fullPathResolver("currentShows.json")
 	if fullPath == "" {
 		return fmt.Errorf("WriteCurrentShows: could not determine full path to currentShows.json")
 	}
@@ -119,7 +121,7 @@ func getFullPath(path string) (fullPath string) {
 
 // readFile reads the contents of the file at the given path.
 func readFile(path string) ([]byte, error) {
-	fullPath := getFullPath(path)
+	fullPath := fullPathResolver(path)
 	if fullPath == "" {
 		return nil, fmt.Errorf("readFile: could not determine full path to %s", path)
 	}

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -197,11 +197,7 @@ func TestWriteCurrentShowsReplacesExistingFileAndRemovesTempFile(t *testing.T) {
 }
 
 func TestReadFileReturnsErrorWhenPathCannotBeResolved(t *testing.T) {
-	originalResolver := fullPathResolver
-	fullPathResolver = func(string) string { return "" }
-	t.Cleanup(func() {
-		fullPathResolver = originalResolver
-	})
+	t.Cleanup(SetFullPathResolverForTest(func(string) string { return "" }))
 
 	if _, err := readFile("shows.json"); err == nil {
 		t.Fatalf("expected error when path cannot be resolved")
@@ -209,11 +205,7 @@ func TestReadFileReturnsErrorWhenPathCannotBeResolved(t *testing.T) {
 }
 
 func TestWriteCurrentShowsReturnsErrorWhenPathCannotBeResolved(t *testing.T) {
-	originalResolver := fullPathResolver
-	fullPathResolver = func(string) string { return "" }
-	t.Cleanup(func() {
-		fullPathResolver = originalResolver
-	})
+	t.Cleanup(SetFullPathResolverForTest(func(string) string { return "" }))
 
 	if err := WriteCurrentShows([]data.Show{}); err == nil {
 		t.Fatalf("expected error when path cannot be resolved")
@@ -224,13 +216,9 @@ func useTempDataDir(t *testing.T) string {
 	t.Helper()
 
 	dir := t.TempDir()
-	originalResolver := fullPathResolver
-	fullPathResolver = func(path string) string {
+	t.Cleanup(SetFullPathResolverForTest(func(path string) string {
 		return filepath.Join(dir, path)
-	}
-	t.Cleanup(func() {
-		fullPathResolver = originalResolver
-	})
+	}))
 
 	return dir
 }

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1,0 +1,248 @@
+package db
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"what-to-watch/data"
+)
+
+func TestReadShows(t *testing.T) {
+	dir := useTempDataDir(t)
+	writeFixture(t, dir, "shows.json", `[
+  {
+    "name": "The Expanse",
+    "genre": "Sci-Fi",
+    "episodes": [10, 13],
+    "provider": "Prime",
+    "currentSeries": 1,
+    "currentEpisode": 2
+  }
+]`)
+
+	shows, err := ReadShows()
+	if err != nil {
+		t.Fatalf("ReadShows returned error: %v", err)
+	}
+
+	if len(shows) != 1 {
+		t.Fatalf("expected 1 show, got %d", len(shows))
+	}
+	if shows[0].Name != "The Expanse" || shows[0].Genre != "Sci-Fi" || shows[0].Provider != "Prime" {
+		t.Fatalf("unexpected show: %+v", shows[0])
+	}
+	if shows[0].CurrentSeries == nil || *shows[0].CurrentSeries != 1 {
+		t.Fatalf("expected current series 1, got %+v", shows[0].CurrentSeries)
+	}
+	if shows[0].CurrentEpisode == nil || *shows[0].CurrentEpisode != 2 {
+		t.Fatalf("expected current episode 2, got %+v", shows[0].CurrentEpisode)
+	}
+}
+
+func TestReadCurrentShows(t *testing.T) {
+	dir := useTempDataDir(t)
+	writeFixture(t, dir, "currentShows.json", `[
+  {
+    "name": "Slow Horses",
+    "genre": "Drama",
+    "episodes": [6],
+    "provider": "Apple TV+",
+    "currentSeries": 1,
+    "currentEpisode": 5
+  }
+]`)
+
+	shows, err := ReadCurrentShows()
+	if err != nil {
+		t.Fatalf("ReadCurrentShows returned error: %v", err)
+	}
+
+	if len(shows) != 1 {
+		t.Fatalf("expected 1 current show, got %d", len(shows))
+	}
+	if shows[0].Name != "Slow Horses" || shows[0].CurrentEpisode == nil || *shows[0].CurrentEpisode != 5 {
+		t.Fatalf("unexpected current show: %+v", shows[0])
+	}
+}
+
+func TestReadFilms(t *testing.T) {
+	dir := useTempDataDir(t)
+	writeFixture(t, dir, "films.json", `[
+  {
+    "name": "Arrival",
+    "genre": "Sci-Fi",
+    "provider": "Netflix"
+  }
+]`)
+
+	films, err := ReadFilms()
+	if err != nil {
+		t.Fatalf("ReadFilms returned error: %v", err)
+	}
+
+	if len(films) != 1 {
+		t.Fatalf("expected 1 film, got %d", len(films))
+	}
+	if films[0] != (data.Film{Name: "Arrival", Genre: "Sci-Fi", Provider: "Netflix"}) {
+		t.Fatalf("unexpected film: %+v", films[0])
+	}
+}
+
+func TestReadersReturnErrorForMissingFiles(t *testing.T) {
+	useTempDataDir(t)
+
+	tests := []struct {
+		name string
+		read func() error
+	}{
+		{name: "ReadShows", read: func() error { _, err := ReadShows(); return err }},
+		{name: "ReadCurrentShows", read: func() error { _, err := ReadCurrentShows(); return err }},
+		{name: "ReadFilms", read: func() error { _, err := ReadFilms(); return err }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.read(); err == nil {
+				t.Fatalf("expected error for missing file")
+			}
+		})
+	}
+}
+
+func TestReadersReturnErrorForInvalidJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileName string
+		read     func() error
+	}{
+		{name: "ReadShows", fileName: "shows.json", read: func() error { _, err := ReadShows(); return err }},
+		{name: "ReadCurrentShows", fileName: "currentShows.json", read: func() error { _, err := ReadCurrentShows(); return err }},
+		{name: "ReadFilms", fileName: "films.json", read: func() error { _, err := ReadFilms(); return err }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := useTempDataDir(t)
+			writeFixture(t, dir, tt.fileName, `{bad json`)
+
+			if err := tt.read(); err == nil {
+				t.Fatalf("expected error for invalid JSON")
+			}
+		})
+	}
+}
+
+func TestWriteCurrentShowsWritesIndentedJSON(t *testing.T) {
+	dir := useTempDataDir(t)
+
+	shows := []data.Show{
+		{
+			Name:           "Severance",
+			Genre:          "Sci-Fi",
+			Episodes:       []int{9},
+			Provider:       "Apple TV+",
+			CurrentSeries:  intPtr(1),
+			CurrentEpisode: intPtr(3),
+		},
+	}
+
+	if err := WriteCurrentShows(shows); err != nil {
+		t.Fatalf("WriteCurrentShows returned error: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, "currentShows.json"))
+	if err != nil {
+		t.Fatalf("reading written file: %v", err)
+	}
+
+	if !strings.Contains(string(raw), "\n  {") {
+		t.Fatalf("expected indented JSON, got %q", string(raw))
+	}
+
+	var written []data.Show
+	if err := json.Unmarshal(raw, &written); err != nil {
+		t.Fatalf("written file is not valid JSON: %v", err)
+	}
+	if len(written) != 1 || written[0].Name != "Severance" {
+		t.Fatalf("unexpected written shows: %+v", written)
+	}
+}
+
+func TestWriteCurrentShowsReplacesExistingFileAndRemovesTempFile(t *testing.T) {
+	dir := useTempDataDir(t)
+	writeFixture(t, dir, "currentShows.json", `[]`)
+
+	if err := WriteCurrentShows([]data.Show{{Name: "Andor", Genre: "Sci-Fi"}}); err != nil {
+		t.Fatalf("WriteCurrentShows returned error: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, "currentShows.json"))
+	if err != nil {
+		t.Fatalf("reading replaced file: %v", err)
+	}
+	if !strings.Contains(string(raw), `"name": "Andor"`) {
+		t.Fatalf("expected file to be replaced with new show, got %s", string(raw))
+	}
+
+	matches, err := filepath.Glob(filepath.Join(dir, "*.tmp"))
+	if err != nil {
+		t.Fatalf("checking temp files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected no temp files, found %v", matches)
+	}
+}
+
+func TestReadFileReturnsErrorWhenPathCannotBeResolved(t *testing.T) {
+	originalResolver := fullPathResolver
+	fullPathResolver = func(string) string { return "" }
+	t.Cleanup(func() {
+		fullPathResolver = originalResolver
+	})
+
+	if _, err := readFile("shows.json"); err == nil {
+		t.Fatalf("expected error when path cannot be resolved")
+	}
+}
+
+func TestWriteCurrentShowsReturnsErrorWhenPathCannotBeResolved(t *testing.T) {
+	originalResolver := fullPathResolver
+	fullPathResolver = func(string) string { return "" }
+	t.Cleanup(func() {
+		fullPathResolver = originalResolver
+	})
+
+	if err := WriteCurrentShows([]data.Show{}); err == nil {
+		t.Fatalf("expected error when path cannot be resolved")
+	}
+}
+
+func useTempDataDir(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	originalResolver := fullPathResolver
+	fullPathResolver = func(path string) string {
+		return filepath.Join(dir, path)
+	}
+	t.Cleanup(func() {
+		fullPathResolver = originalResolver
+	})
+
+	return dir
+}
+
+func writeFixture(t *testing.T, dir, name, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+		t.Fatalf("writing fixture %s: %v", name, err)
+	}
+}
+
+func intPtr(i int) *int {
+	return &i
+}

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -1,0 +1,323 @@
+package handlers
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"what-to-watch/data"
+	"what-to-watch/db"
+)
+
+func TestGetCurrentlyWatchingShows(t *testing.T) {
+	dir := useTempDataDir(t)
+	writeFixture(t, dir, "currentShows.json", `[
+  {
+    "name": "Slow Horses",
+    "genre": "Drama",
+    "episodes": [6],
+    "provider": "Apple TV+",
+    "currentSeries": 1,
+    "currentEpisode": 5
+  },
+  {
+    "name": "Unstarted Comedy",
+    "genre": "Comedy",
+    "episodes": [8],
+    "provider": "Netflix"
+  }
+]`)
+
+	shows, err := GetCurrentlyWatchingShows()
+	if err != nil {
+		t.Fatalf("GetCurrentlyWatchingShows returned error: %v", err)
+	}
+
+	expected := []data.Show{
+		{
+			Name:           "Slow Horses",
+			Genre:          "Drama",
+			Episodes:       []int{6},
+			Provider:       "Apple TV+",
+			CurrentSeries:  intPtr(1),
+			CurrentEpisode: intPtr(5),
+			Series:         "1",
+			Episode:        "5",
+		},
+	}
+	if !reflect.DeepEqual(shows, expected) {
+		t.Fatalf("expected %+v, got %+v", expected, shows)
+	}
+}
+
+func TestMarkShowWatchedIncrementsAndPersistsEpisode(t *testing.T) {
+	dir := useTempDataDir(t)
+	writeFixture(t, dir, "currentShows.json", `[
+  {
+    "name": "Severance",
+    "genre": "Sci-Fi",
+    "episodes": [9],
+    "provider": "Apple TV+",
+    "currentSeries": 1,
+    "currentEpisode": 3
+  }
+]`)
+
+	completed, err := MarkShowWatched(1)
+	if err != nil {
+		t.Fatalf("MarkShowWatched returned error: %v", err)
+	}
+	if completed {
+		t.Fatalf("expected show not to be completed")
+	}
+
+	shows := readCurrentShowsFixture(t, dir)
+	if len(shows) != 1 {
+		t.Fatalf("expected 1 persisted show, got %d", len(shows))
+	}
+	if shows[0].CurrentEpisode == nil || *shows[0].CurrentEpisode != 4 {
+		t.Fatalf("expected persisted episode 4, got %+v", shows[0])
+	}
+	if shows[0].CurrentSeries == nil || *shows[0].CurrentSeries != 1 {
+		t.Fatalf("expected persisted series 1, got %+v", shows[0])
+	}
+}
+
+func TestMarkShowWatchedCompletesAndPersistsShow(t *testing.T) {
+	dir := useTempDataDir(t)
+	writeFixture(t, dir, "currentShows.json", `[
+  {
+    "name": "One Episode Show",
+    "genre": "Drama",
+    "episodes": [1],
+    "provider": "BBC",
+    "currentSeries": 1,
+    "currentEpisode": 1
+  }
+]`)
+
+	completed, err := MarkShowWatched(1)
+	if err != nil {
+		t.Fatalf("MarkShowWatched returned error: %v", err)
+	}
+	if !completed {
+		t.Fatalf("expected show to be completed")
+	}
+
+	shows := readCurrentShowsFixture(t, dir)
+	if len(shows) != 1 {
+		t.Fatalf("expected 1 persisted show, got %d", len(shows))
+	}
+	if shows[0].CurrentSeries != nil || shows[0].CurrentEpisode != nil {
+		t.Fatalf("expected persisted show to clear current position, got %+v", shows[0])
+	}
+}
+
+func TestGetAllFilms(t *testing.T) {
+	dir := useTempDataDir(t)
+	writeFixture(t, dir, "films.json", `[
+  {
+    "name": "Arrival",
+    "genre": "Sci-Fi",
+    "provider": "Netflix"
+  },
+  {
+    "name": "Paddington 2",
+    "genre": "Comedy",
+    "provider": "BBC iPlayer"
+  }
+]`)
+
+	films, err := GetAllFilms()
+	if err != nil {
+		t.Fatalf("GetAllFilms returned error: %v", err)
+	}
+
+	expected := []data.Film{
+		{Name: "Arrival", Genre: "Sci-Fi", Provider: "Netflix"},
+		{Name: "Paddington 2", Genre: "Comedy", Provider: "BBC iPlayer"},
+	}
+	if !reflect.DeepEqual(films, expected) {
+		t.Fatalf("expected %+v, got %+v", expected, films)
+	}
+}
+
+func TestGetAvailableGenres(t *testing.T) {
+	dir := useTempDataDir(t)
+	writeShowsFixture(t, dir)
+
+	genres, err := GetAvailableGenres()
+	if err != nil {
+		t.Fatalf("GetAvailableGenres returned error: %v", err)
+	}
+
+	expected := map[string]bool{"Drama": true, "Comedy": true, "Sci-Fi": true}
+	if len(genres) != len(expected) {
+		t.Fatalf("expected %d genres, got %d: %v", len(expected), len(genres), genres)
+	}
+	for _, genre := range genres {
+		if !expected[genre] {
+			t.Fatalf("unexpected genre %q in %v", genre, genres)
+		}
+	}
+}
+
+func TestGetUnwatchedShowsByGenre(t *testing.T) {
+	dir := useTempDataDir(t)
+	writeShowsFixture(t, dir)
+
+	shows, err := GetUnwatchedShowsByGenre("Drama")
+	if err != nil {
+		t.Fatalf("GetUnwatchedShowsByGenre returned error: %v", err)
+	}
+
+	expected := []data.Show{
+		{Name: "Unstarted Drama", Genre: "Drama", Episodes: []int{6}, Provider: "Netflix"},
+	}
+	if !reflect.DeepEqual(shows, expected) {
+		t.Fatalf("expected %+v, got %+v", expected, shows)
+	}
+}
+
+func TestHandlersSurfaceReadErrors(t *testing.T) {
+	useTempDataDir(t)
+
+	tests := []struct {
+		name      string
+		call      func() error
+		wantError string
+	}{
+		{
+			name: "GetCurrentlyWatchingShows",
+			call: func() error {
+				_, err := GetCurrentlyWatchingShows()
+				return err
+			},
+			wantError: "error reading shows",
+		},
+		{
+			name: "MarkShowWatched",
+			call: func() error {
+				_, err := MarkShowWatched(1)
+				return err
+			},
+			wantError: "error reading shows",
+		},
+		{
+			name: "GetAllFilms",
+			call: func() error {
+				_, err := GetAllFilms()
+				return err
+			},
+			wantError: "error reading films",
+		},
+		{
+			name: "GetAvailableGenres",
+			call: func() error {
+				_, err := GetAvailableGenres()
+				return err
+			},
+			wantError: "GetAvailableGenres: error reading shows",
+		},
+		{
+			name: "GetUnwatchedShowsByGenre",
+			call: func() error {
+				_, err := GetUnwatchedShowsByGenre("Drama")
+				return err
+			},
+			wantError: "GetUnwatchedShowsByGenre: error reading shows",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.call()
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("expected error containing %q, got %q", tt.wantError, err.Error())
+			}
+		})
+	}
+}
+
+func useTempDataDir(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	t.Cleanup(db.SetFullPathResolverForTest(func(path string) string {
+		return filepath.Join(dir, path)
+	}))
+
+	return dir
+}
+
+func writeShowsFixture(t *testing.T, dir string) {
+	t.Helper()
+
+	writeFixture(t, dir, "shows.json", `[
+  {
+    "name": "Unstarted Drama",
+    "genre": "Drama",
+    "episodes": [6],
+    "provider": "Netflix"
+  },
+  {
+    "name": "Current Drama",
+    "genre": "Drama",
+    "episodes": [8],
+    "provider": "Apple TV+",
+    "currentSeries": 1,
+    "currentEpisode": 2
+  },
+  {
+    "name": "Unstarted Comedy",
+    "genre": "Comedy",
+    "episodes": [10],
+    "provider": "Disney+"
+  },
+  {
+    "name": "Unstarted Sci-Fi",
+    "genre": "Sci-Fi",
+    "episodes": [9],
+    "provider": "Prime"
+  },
+  {
+    "name": "Missing Genre",
+    "episodes": [4],
+    "provider": "Channel 4"
+  }
+]`)
+}
+
+func writeFixture(t *testing.T, dir, name, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+		t.Fatalf("writing fixture %s: %v", name, err)
+	}
+}
+
+func readCurrentShowsFixture(t *testing.T, dir string) []data.Show {
+	t.Helper()
+
+	raw, err := os.ReadFile(filepath.Join(dir, "currentShows.json"))
+	if err != nil {
+		t.Fatalf("reading current shows fixture: %v", err)
+	}
+
+	var shows []data.Show
+	if err := json.Unmarshal(raw, &shows); err != nil {
+		t.Fatalf("unmarshaling current shows fixture: %v", err)
+	}
+
+	return shows
+}
+
+func intPtr(i int) *int {
+	return &i
+}

--- a/main.go
+++ b/main.go
@@ -3,10 +3,19 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
 
 	"what-to-watch/cmd/cli"
-	"what-to-watch/cmd/http"
+	apphttp "what-to-watch/cmd/http"
+)
+
+var (
+	runCLI          = cli.Run
+	startHTTPServer = func(port int) error {
+		server := apphttp.NewServer(port)
+		return server.Start()
+	}
 )
 
 func main() {
@@ -15,17 +24,24 @@ func main() {
 	port := flag.Int("port", 8080, "HTTP server port (only used in http mode)")
 	flag.Parse()
 
-	switch *mode {
+	if exitCode := run(*mode, *port, os.Stderr); exitCode != 0 {
+		os.Exit(exitCode)
+	}
+}
+
+func run(mode string, port int, stderr io.Writer) int {
+	switch mode {
 	case "cli":
-		cli.Run()
+		runCLI()
+		return 0
 	case "http":
-		server := http.NewServer(*port)
-		if err := server.Start(); err != nil {
-			fmt.Fprintf(os.Stderr, "HTTP server error: %v\n", err)
-			os.Exit(1)
+		if err := startHTTPServer(port); err != nil {
+			fmt.Fprintf(stderr, "HTTP server error: %v\n", err)
+			return 1
 		}
+		return 0
 	default:
-		fmt.Fprintf(os.Stderr, "Invalid mode: %s. Use 'cli' or 'http'.\n", *mode)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "Invalid mode: %s. Use 'cli' or 'http'.\n", mode)
+		return 1
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRunCLIMode(t *testing.T) {
+	restore := stubMainFunctions()
+	t.Cleanup(restore)
+
+	called := false
+	runCLI = func() {
+		called = true
+	}
+
+	var stderr bytes.Buffer
+	exitCode := run("cli", 8080, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if !called {
+		t.Fatalf("expected CLI runner to be called")
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr output, got %q", stderr.String())
+	}
+}
+
+func TestRunHTTPMode(t *testing.T) {
+	restore := stubMainFunctions()
+	t.Cleanup(restore)
+
+	var gotPort int
+	startHTTPServer = func(port int) error {
+		gotPort = port
+		return nil
+	}
+
+	var stderr bytes.Buffer
+	exitCode := run("http", 9090, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if gotPort != 9090 {
+		t.Fatalf("expected HTTP server port 9090, got %d", gotPort)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr output, got %q", stderr.String())
+	}
+}
+
+func TestRunHTTPModeReturnsError(t *testing.T) {
+	restore := stubMainFunctions()
+	t.Cleanup(restore)
+
+	startHTTPServer = func(int) error {
+		return errors.New("listen failed")
+	}
+
+	var stderr bytes.Buffer
+	exitCode := run("http", 8080, &stderr)
+
+	if exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "HTTP server error: listen failed") {
+		t.Fatalf("expected HTTP error message, got %q", stderr.String())
+	}
+}
+
+func TestRunInvalidMode(t *testing.T) {
+	restore := stubMainFunctions()
+	t.Cleanup(restore)
+
+	var stderr bytes.Buffer
+	exitCode := run("bogus", 8080, &stderr)
+
+	if exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "Invalid mode: bogus. Use 'cli' or 'http'.") {
+		t.Fatalf("expected invalid mode message, got %q", stderr.String())
+	}
+}
+
+func stubMainFunctions() func() {
+	originalRunCLI := runCLI
+	originalStartHTTPServer := startHTTPServer
+
+	runCLI = func() {}
+	startHTTPServer = func(int) error { return nil }
+
+	return func() {
+		runCLI = originalRunCLI
+		startHTTPServer = originalStartHTTPServer
+	}
+}

--- a/plans/15-increase-unit-and-integration-testing.md
+++ b/plans/15-increase-unit-and-integration-testing.md
@@ -1,0 +1,264 @@
+# Issue #15: Increase Unit and Integration Testing
+
+## Overview
+
+GitHub issue #15 asks for more unit and integration testing so future feature work can be made with higher confidence. The current test suite already covers most pure show business logic and a large portion of HTTP handler behavior, but several important boundaries are still untested:
+
+- CLI output formatting and user input flows
+- `handlers` package orchestration between `db` and `shows`
+- `db` JSON read/write and path resolution behavior
+- HTTP routing/server integration beyond direct handler method tests
+- `main.go` mode selection and invalid-mode behavior
+
+Current baseline from `go test ./... -cover`:
+
+- `what-to-watch`: 0.0%
+- `what-to-watch/cmd/cli`: 0.0%
+- `what-to-watch/cmd/http`: 73.1%
+- `what-to-watch/data`: no test files
+- `what-to-watch/db`: 0.0%
+- `what-to-watch/handlers`: 0.0%
+- `what-to-watch/shows`: 94.2%
+
+## Goals
+
+- Add targeted unit tests around packages with 0% coverage.
+- Add integration tests that exercise real package wiring without mutating canonical JSON files.
+- Preserve current behavior and keep production refactors minimal.
+- Avoid external dependencies; use Go standard library test tools.
+
+## Non-Goals
+
+- Do not redesign CLI or HTTP APIs as part of this issue.
+- Do not add broad snapshot/golden-file infrastructure unless it stays simple and local.
+- Do not make tests depend on modifying `db/currentShows.json`, `db/shows.json`, or `db/films.json`.
+
+## Proposed Implementation Steps
+
+### 1. Add a Testability Layer for Data File Paths
+
+Files:
+
+- `db/db.go`
+- new `db/db_test.go`
+
+Plan:
+
+- Add a package-level path resolver variable in `db`, defaulting to the existing `getFullPath` behavior.
+- Use that resolver from `readFile` and `WriteCurrentShows`.
+- In tests, temporarily override the resolver with `t.Cleanup` to point at `t.TempDir()` fixtures.
+- Keep `getFullPath` behavior unchanged for production and existing commands.
+
+Unit tests:
+
+- `ReadShows` parses a valid `shows.json`.
+- `ReadCurrentShows` parses a valid `currentShows.json`.
+- `ReadFilms` parses a valid `films.json`.
+- Each reader returns an error for missing files.
+- Each reader returns an error for invalid JSON.
+- `WriteCurrentShows` writes indented JSON to the resolved path.
+- `WriteCurrentShows` replaces an existing file without leaving temp files behind.
+
+Acceptance criteria:
+
+- `db` tests never touch repository JSON files.
+- Tests verify both successful JSON parsing and common failure paths.
+
+### 2. Add Handler Integration Tests with Temporary Data
+
+Files:
+
+- `handlers/handlers.go`
+- new `handlers/handlers_test.go`
+
+Plan:
+
+- Reuse the `db` test path override pattern to run handlers against temporary JSON fixtures.
+- Treat these as package-level integration tests because they exercise `handlers`, `db`, and `shows` together.
+- Use small fixtures with clear expected state transitions.
+
+Tests:
+
+- `GetCurrentlyWatchingShows` returns only currently watching shows with computed series/episode display fields.
+- `MarkShowWatched` increments an episode and persists the update.
+- `MarkShowWatched` handles episode/series completion and persists the update.
+- `GetAllFilms` returns films from the temp fixture.
+- `GetAvailableGenres` returns unique genres from temp `shows.json`.
+- `GetUnwatchedShowsByGenre` returns unwatched shows for a genre.
+- Read/write failures are surfaced with handler-specific context.
+
+Acceptance criteria:
+
+- Tests validate persisted data after `MarkShowWatched`.
+- Handler tests fail if the handler layer stops using shared business logic.
+
+### 3. Add CLI Formatting Unit Tests
+
+Files:
+
+- new `cmd/cli/format_test.go`
+
+Plan:
+
+- Test pure formatting helpers before adding tests for interactive flows.
+- Use exact string expectations for small tables where alignment matters.
+- Cover empty-state text because it is user-facing behavior.
+
+Tests:
+
+- `formatShowsTable` with multiple rows and varying column widths.
+- `formatShowsTable` empty state.
+- `formatShowsByGenreTable` with data.
+- `formatShowsByGenreTable` empty state.
+- `formatFilmsTable` with data.
+- `formatFilmsTable` empty state.
+
+Acceptance criteria:
+
+- CLI table regressions are caught without needing to run the interactive CLI.
+
+### 4. Add CLI Flow Tests with Injectable Handler Functions
+
+Files:
+
+- `cmd/cli/cli.go`
+- new `cmd/cli/cli_test.go`
+
+Plan:
+
+- Introduce small package-level function variables in `cmd/cli` for calls currently made directly to `handlers`.
+- Default them to the existing handler functions.
+- In tests, override them with stubs and restore with `t.Cleanup`.
+- Capture `os.Stdout` and provide `bufio.Reader` input from strings.
+
+Tests:
+
+- `viewShows` displays shows and cancels on `0`.
+- `viewShows` rejects non-numeric input.
+- `viewShows` calls `MarkShowWatched` for valid numeric input and prints completed/non-completed messages.
+- `viewFilms` displays films.
+- `viewShowsByGenre` displays available genres, handles cancel/invalid selection, and displays selected genre results.
+- Error paths print a concise `Error:` line when handler functions fail.
+
+Acceptance criteria:
+
+- Interactive paths are covered without reading or writing real data files.
+- Production CLI behavior remains unchanged.
+
+### 5. Expand HTTP Tests into Router-Level Integration Tests
+
+Files:
+
+- `cmd/http/http.go`
+- `cmd/http/http_test.go`
+
+Plan:
+
+- Add a `routes()` or `ServeHTTP` helper on `Server` that returns an `http.Handler` using a local `http.ServeMux`.
+- Have `Start` call the same route builder and pass it to `http.ListenAndServe`.
+- Keep existing direct handler tests.
+- Add `httptest.NewServer` integration tests using `NewServerWithHandler`.
+
+Tests:
+
+- `GET /shows` routes to currently watching shows.
+- `GET /shows?genre=Drama` routes to genre filtering.
+- `POST /shows/watch?index=1` routes to mark watched.
+- `GET /films`, `GET /genres`, and `GET /health` return JSON responses.
+- Unsupported methods return `405`.
+- Unknown routes return `404`.
+
+Acceptance criteria:
+
+- Route registration is tested without binding a real port.
+- HTTP tests use the same mux that production uses.
+
+### 6. Add Main Package Tests
+
+Files:
+
+- `main.go`
+- new `main_test.go`
+
+Plan:
+
+- Extract mode dispatch into a small function, for example `run(mode string, port int) int`, where return value is an exit code.
+- Keep `main()` responsible for flag parsing and `os.Exit`.
+- Use injectable CLI and HTTP start functions so tests can verify dispatch without starting a server.
+
+Tests:
+
+- `run("cli", 8080)` calls CLI runner and returns `0`.
+- `run("http", 9090)` starts HTTP mode with the requested port and returns `0` on success.
+- HTTP start errors return non-zero.
+- Invalid mode returns non-zero and writes the current invalid-mode message.
+
+Acceptance criteria:
+
+- Main dispatch is covered without launching interactive input or a long-running server.
+- The public command-line behavior remains the same.
+
+### 7. Add Coverage Reporting to Validation Workflow
+
+Files:
+
+- `README.md`
+- `AGENTS.md`
+- `.github/copilot-instructions.md` if present
+
+Plan:
+
+- Document the coverage command alongside existing validation commands:
+
+```sh
+go test ./... -cover
+```
+
+- Optionally add a local deeper coverage command for contributors:
+
+```sh
+go test ./... -coverprofile=coverage.out
+go tool cover -func=coverage.out
+```
+
+Acceptance criteria:
+
+- Documentation tells contributors how to check coverage locally.
+- Agent instructions remain aligned with repository workflow.
+
+## Suggested Order
+
+1. Add `db` testability layer and `db` unit tests.
+2. Add handler integration tests using temporary JSON fixtures.
+3. Add CLI formatting tests.
+4. Add CLI flow tests with injectable handler functions.
+5. Refactor HTTP routing minimally and add router-level integration tests.
+6. Extract main dispatch and add main package tests.
+7. Update documentation with coverage commands.
+
+## Validation Commands
+
+Run after implementation:
+
+```sh
+go vet ./...
+go build ./...
+go test ./...
+go test ./... -cover
+```
+
+For detailed coverage:
+
+```sh
+go test ./... -coverprofile=coverage.out
+go tool cover -func=coverage.out
+```
+
+## Final Acceptance Criteria
+
+- New tests cover `db`, `handlers`, `cmd/cli`, and `main`.
+- HTTP tests include route-level integration coverage.
+- Tests do not mutate canonical JSON data under `db/`.
+- All validation commands pass.
+- Overall package coverage improves materially from the current baseline.
+- Any production changes are limited to small testability seams and shared route/dispatch helpers.


### PR DESCRIPTION
## Summary
- Add db unit tests with isolated temp-file fixtures
- Add handler integration tests, CLI formatting and flow tests, HTTP route integration tests, and main dispatch tests
- Document coverage commands in README, AGENTS, and Copilot instructions

## Validation
- go vet ./...
- go build ./...
- go test ./...
- go test ./... -cover

Closes #15