### PR TITLE
Consolidate show data storage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,11 +16,11 @@ Key files and intent
 - `cmd/cli/cli.go` — interactive CLI interface; calls handlers.
 - `cmd/http/http.go` — HTTP REST API server; implements `Handler` interface pattern for dependency injection in tests.
 - `cmd/http/http_test.go` — Table-driven tests for all HTTP handler functions. Uses `mockHandler` to stub business logic calls.
-- `db/db.go` — read/write helpers and `getFullPath` logic for `db/currentShows.json` and `db/films.json` (includes `ReadCurrentShows`, `WriteCurrentShows`, and `ReadFilms`).
+- `db/db.go` — read/write helpers and `getFullPath` logic for `db/shows.json` and `db/films.json` (includes category readers, `WriteCurrentShows`, and `ReadFilms`).
 - `data/data.go` — `Show` and `Film` struct types used across packages.
 - `shows/shows.go` — business logic: `GetCurrentlyWatching`, `MarkEpisodeWatched`, `GetUniqueGenres`, and `GetUnwatchedShowsByGenre`.
 - `shows/shows_test.go` — unit tests for `shows` package (fast, in-memory).
-- `db/currentShows.json` and `db/films.json` — canonical on-disk data used when running `go run .`.
+- `db/shows.json` and `db/films.json` — canonical on-disk data used when running `go run .`. Show categories are inferred from current position fields and the `rewatch` flag.
 
 Common Commands (PowerShell)
 
@@ -51,7 +51,7 @@ Testing & Validation
 
 - Unit tests live under `shows/` for business logic and `cmd/http/` for HTTP handlers. They are fast and authoritative.
 - HTTP handler tests use table-driven approach with `mockHandler` implementing the `Handler` interface for dependency injection.
-- Tests should not rely on `db/currentShows.json` being modified — tests use in-memory data.
+- Tests should not rely on `db/shows.json` being modified — tests use isolated fixture files.
 - After implementing changes, run:
 
 ```sh
@@ -85,9 +85,9 @@ Documentation
 
 Data and File I/O Notes
 
-- `db.ReadCurrentShows()` searches for `currentShows.json` next to the executable and falls back to the source `db` directory. Built binaries may expect `currentShows.json` next to the binary, whereas `go run .` finds the source `db/currentShows.json`.
+- Show readers search for `shows.json` next to the executable and fall back to the source `db` directory. Built binaries may expect `shows.json` next to the binary, whereas `go run .` finds the source `db/shows.json`.
 - `db.ReadFilms()` searches for `films.json` next to the executable and falls back to the source `db` directory. Built binaries may expect `films.json` next to the binary, whereas `go run .` finds the source `db/films.json`.
-- `db.WriteCurrentShows()` writes atomically (temp file then rename). Be careful not to accidentally commit runtime-modified JSON files.
+- `db.WriteCurrentShows()` updates the current records in `shows.json` and writes atomically (temp file then rename). Be careful not to accidentally commit runtime-modified JSON files.
 
 Agent Behaviour & Tooling Conventions
 
@@ -114,7 +114,7 @@ Safety and Scope
 If You Need More
 
 - If any CI or test failures are unclear, run the failing commands locally and include the exact error output in your report.
-- When in doubt about changing `db/currentShows.json` on-disk, ask for guidance or open a draft PR.
+- When in doubt about changing `db/shows.json` on-disk, ask for guidance or open a draft PR.
 
 Contact / Handoff
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This program can be run as an interactive CLI or as an HTTP server, both using t
 
 **Films**: View your film collection with genre and provider information.
 
+Show data is stored in `db/shows.json` as one array. Shows with
+`currentSeries`/`currentEpisode` are currently watching; shows with
+`rewatch: true` are queued for rewatch; records with neither are unwatched.
+
 The `plans/` directory contains AI-generated plans for implementations.
 
 See GitHub Issues for future plans. New Issues and Pull Requests are welcome.

--- a/data/data.go
+++ b/data/data.go
@@ -5,6 +5,8 @@ type Show struct {
 	Genre    string `json:"genre"`
 	Episodes []int  `json:"episodes"`
 	Provider string `json:"provider"`
+	// Rewatch is true when the show is queued for watching again.
+	Rewatch bool `json:"rewatch,omitempty"`
 	// CurrentSeries is only set if the user is currently watching this show
 	CurrentSeries *int   `json:"currentSeries,omitempty"`
 	Series        string `json:"-"`

--- a/db/db.go
+++ b/db/db.go
@@ -22,11 +22,10 @@ func SetFullPathResolverForTest(resolver func(string) string) func() {
 	}
 }
 
-// ReadShows reads the shows from the shows.json file and returns a slice of Show structs.
-func ReadShows() ([]data.Show, error) {
+func readShows() ([]data.Show, error) {
 	raw, err := readFile("shows.json")
 	if err != nil {
-		return nil, fmt.Errorf("ReadShows: error reading file \n err=%w", err)
+		return nil, fmt.Errorf("readShows: error reading file \n err=%w", err)
 	}
 
 	var shows []data.Show
@@ -37,19 +36,54 @@ func ReadShows() ([]data.Show, error) {
 	return shows, nil
 }
 
-// ReadCurrentShows reads the shows from the currentShows.json file and returns a slice of Show structs.
-func ReadCurrentShows() ([]data.Show, error) {
-	raw, err := readFile("currentShows.json")
+// ReadAllShows reads every show from shows.json.
+func ReadAllShows() ([]data.Show, error) {
+	return readShows()
+}
+
+// ReadUnwatchedShows returns shows that have no current position and are not marked for rewatch.
+func ReadUnwatchedShows() ([]data.Show, error) {
+	shows, err := readShows()
 	if err != nil {
-		return nil, fmt.Errorf("ReadCurrentShows: error reading file \n err=%w", err)
+		return nil, fmt.Errorf("ReadUnwatchedShows: %w", err)
 	}
-
-	var shows []data.Show
-	if err := json.Unmarshal(raw, &shows); err != nil {
-		return nil, err
+	filtered := make([]data.Show, 0)
+	for _, show := range shows {
+		if show.CurrentSeries == nil && show.CurrentEpisode == nil && !show.Rewatch {
+			filtered = append(filtered, show)
+		}
 	}
+	return filtered, nil
+}
 
-	return shows, nil
+// ReadCurrentShows returns shows with a current series or episode position.
+func ReadCurrentShows() ([]data.Show, error) {
+	shows, err := readShows()
+	if err != nil {
+		return nil, fmt.Errorf("ReadCurrentShows: %w", err)
+	}
+	filtered := make([]data.Show, 0)
+	for _, show := range shows {
+		if show.CurrentSeries != nil || show.CurrentEpisode != nil {
+			filtered = append(filtered, show)
+		}
+	}
+	return filtered, nil
+}
+
+// ReadRewatchShows returns shows marked for rewatch.
+func ReadRewatchShows() ([]data.Show, error) {
+	shows, err := readShows()
+	if err != nil {
+		return nil, fmt.Errorf("ReadRewatchShows: %w", err)
+	}
+	filtered := make([]data.Show, 0)
+	for _, show := range shows {
+		if show.Rewatch {
+			filtered = append(filtered, show)
+		}
+	}
+	return filtered, nil
 }
 
 // ReadFilms reads the films from the films.json file and returns a slice of Film structs.
@@ -67,23 +101,36 @@ func ReadFilms() ([]data.Film, error) {
 	return films, nil
 }
 
-// WriteCurrentShows writes the provided shows slice to the currentShows.json file.
+// WriteCurrentShows replaces the current-position records in shows.json with the provided slice.
 // It writes to a temporary file in the same directory and renames it
 // to avoid corrupting the file on failure.
 func WriteCurrentShows(shows []data.Show) error {
-	raw, err := json.MarshalIndent(shows, "", "  ")
+	existing, err := readShows()
+	if err != nil {
+		return fmt.Errorf("WriteCurrentShows: error reading shows.json \n err=%w", err)
+	}
+
+	merged := make([]data.Show, 0, len(existing)+len(shows))
+	for _, show := range existing {
+		if show.CurrentSeries == nil && show.CurrentEpisode == nil {
+			merged = append(merged, show)
+		}
+	}
+	merged = append(merged, shows...)
+
+	raw, err := json.MarshalIndent(merged, "", "  ")
 	if err != nil {
 		return err
 	}
 
-	fullPath := fullPathResolver("currentShows.json")
+	fullPath := fullPathResolver("shows.json")
 	if fullPath == "" {
-		return fmt.Errorf("WriteCurrentShows: could not determine full path to currentShows.json")
+		return fmt.Errorf("WriteCurrentShows: could not determine full path to shows.json")
 	}
 
 	// create temp file in same directory to ensure atomic rename
 	dir := filepath.Dir(fullPath)
-	tmpFile, err := os.CreateTemp(dir, "currentShows-*.json.tmp")
+	tmpFile, err := os.CreateTemp(dir, "shows-*.json.tmp")
 	if err != nil {
 		return fmt.Errorf("WriteCurrentShows: error creating temp file \n err=%w fullPath=%s", err, fullPath)
 	}
@@ -138,7 +185,7 @@ func readFile(path string) ([]byte, error) {
 
 	raw, err := os.ReadFile(fullPath)
 	if err != nil {
-		return nil, fmt.Errorf("ReadFilms: error reading file \n err=%w path=%s fullPath=%s", err, path, fullPath)
+		return nil, fmt.Errorf("readFile: error reading file \n err=%w path=%s fullPath=%s", err, path, fullPath)
 	}
 
 	return raw, nil

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -10,7 +10,7 @@ import (
 	"what-to-watch/data"
 )
 
-func TestReadShows(t *testing.T) {
+func TestReadAllShows(t *testing.T) {
 	dir := useTempDataDir(t)
 	writeFixture(t, dir, "shows.json", `[
   {
@@ -23,9 +23,9 @@ func TestReadShows(t *testing.T) {
   }
 ]`)
 
-	shows, err := ReadShows()
+	shows, err := ReadAllShows()
 	if err != nil {
-		t.Fatalf("ReadShows returned error: %v", err)
+		t.Fatalf("ReadAllShows returned error: %v", err)
 	}
 
 	if len(shows) != 1 {
@@ -44,7 +44,7 @@ func TestReadShows(t *testing.T) {
 
 func TestReadCurrentShows(t *testing.T) {
 	dir := useTempDataDir(t)
-	writeFixture(t, dir, "currentShows.json", `[
+	writeFixture(t, dir, "shows.json", `[
   {
     "name": "Slow Horses",
     "genre": "Drama",
@@ -65,6 +65,28 @@ func TestReadCurrentShows(t *testing.T) {
 	}
 	if shows[0].Name != "Slow Horses" || shows[0].CurrentEpisode == nil || *shows[0].CurrentEpisode != 5 {
 		t.Fatalf("unexpected current show: %+v", shows[0])
+	}
+}
+
+func TestReadShowCategories(t *testing.T) {
+	dir := useTempDataDir(t)
+	writeFixture(t, dir, "shows.json", `[
+  {"name":"Unwatched","genre":"Drama","episodes":[6],"provider":"Netflix"},
+  {"name":"Current","genre":"Drama","episodes":[6],"provider":"Netflix","currentSeries":1,"currentEpisode":2},
+  {"name":"Rewatch","genre":"Drama","episodes":[6],"provider":"Netflix","rewatch":true}
+]`)
+
+	unwatched, err := ReadUnwatchedShows()
+	if err != nil || len(unwatched) != 1 || unwatched[0].Name != "Unwatched" {
+		t.Fatalf("unexpected unwatched shows: %v %+v", err, unwatched)
+	}
+	current, err := ReadCurrentShows()
+	if err != nil || len(current) != 1 || current[0].Name != "Current" {
+		t.Fatalf("unexpected current shows: %v %+v", err, current)
+	}
+	rewatch, err := ReadRewatchShows()
+	if err != nil || len(rewatch) != 1 || rewatch[0].Name != "Rewatch" {
+		t.Fatalf("unexpected rewatch shows: %v %+v", err, rewatch)
 	}
 }
 
@@ -98,8 +120,10 @@ func TestReadersReturnErrorForMissingFiles(t *testing.T) {
 		name string
 		read func() error
 	}{
-		{name: "ReadShows", read: func() error { _, err := ReadShows(); return err }},
+		{name: "ReadAllShows", read: func() error { _, err := ReadAllShows(); return err }},
+		{name: "ReadUnwatchedShows", read: func() error { _, err := ReadUnwatchedShows(); return err }},
 		{name: "ReadCurrentShows", read: func() error { _, err := ReadCurrentShows(); return err }},
+		{name: "ReadRewatchShows", read: func() error { _, err := ReadRewatchShows(); return err }},
 		{name: "ReadFilms", read: func() error { _, err := ReadFilms(); return err }},
 	}
 
@@ -118,8 +142,10 @@ func TestReadersReturnErrorForInvalidJSON(t *testing.T) {
 		fileName string
 		read     func() error
 	}{
-		{name: "ReadShows", fileName: "shows.json", read: func() error { _, err := ReadShows(); return err }},
-		{name: "ReadCurrentShows", fileName: "currentShows.json", read: func() error { _, err := ReadCurrentShows(); return err }},
+		{name: "ReadAllShows", fileName: "shows.json", read: func() error { _, err := ReadAllShows(); return err }},
+		{name: "ReadUnwatchedShows", fileName: "shows.json", read: func() error { _, err := ReadUnwatchedShows(); return err }},
+		{name: "ReadCurrentShows", fileName: "shows.json", read: func() error { _, err := ReadCurrentShows(); return err }},
+		{name: "ReadRewatchShows", fileName: "shows.json", read: func() error { _, err := ReadRewatchShows(); return err }},
 		{name: "ReadFilms", fileName: "films.json", read: func() error { _, err := ReadFilms(); return err }},
 	}
 
@@ -137,6 +163,7 @@ func TestReadersReturnErrorForInvalidJSON(t *testing.T) {
 
 func TestWriteCurrentShowsWritesIndentedJSON(t *testing.T) {
 	dir := useTempDataDir(t)
+	writeFixture(t, dir, "shows.json", `[]`)
 
 	shows := []data.Show{
 		{
@@ -153,7 +180,7 @@ func TestWriteCurrentShowsWritesIndentedJSON(t *testing.T) {
 		t.Fatalf("WriteCurrentShows returned error: %v", err)
 	}
 
-	raw, err := os.ReadFile(filepath.Join(dir, "currentShows.json"))
+	raw, err := os.ReadFile(filepath.Join(dir, "shows.json"))
 	if err != nil {
 		t.Fatalf("reading written file: %v", err)
 	}
@@ -173,13 +200,13 @@ func TestWriteCurrentShowsWritesIndentedJSON(t *testing.T) {
 
 func TestWriteCurrentShowsReplacesExistingFileAndRemovesTempFile(t *testing.T) {
 	dir := useTempDataDir(t)
-	writeFixture(t, dir, "currentShows.json", `[]`)
+	writeFixture(t, dir, "shows.json", `[]`)
 
 	if err := WriteCurrentShows([]data.Show{{Name: "Andor", Genre: "Sci-Fi"}}); err != nil {
 		t.Fatalf("WriteCurrentShows returned error: %v", err)
 	}
 
-	raw, err := os.ReadFile(filepath.Join(dir, "currentShows.json"))
+	raw, err := os.ReadFile(filepath.Join(dir, "shows.json"))
 	if err != nil {
 		t.Fatalf("reading replaced file: %v", err)
 	}
@@ -193,6 +220,26 @@ func TestWriteCurrentShowsReplacesExistingFileAndRemovesTempFile(t *testing.T) {
 	}
 	if len(matches) != 0 {
 		t.Fatalf("expected no temp files, found %v", matches)
+	}
+}
+
+func TestWriteCurrentShowsPreservesOtherCategories(t *testing.T) {
+	dir := useTempDataDir(t)
+	writeFixture(t, dir, "shows.json", `[
+  {"name":"Unwatched","provider":"Netflix"},
+  {"name":"Current","provider":"Netflix","currentSeries":1,"currentEpisode":1},
+  {"name":"Rewatch","provider":"Netflix","rewatch":true}
+]`)
+
+	if err := WriteCurrentShows([]data.Show{{Name: "Current", Provider: "Netflix", CurrentSeries: intPtr(1), CurrentEpisode: intPtr(2)}}); err != nil {
+		t.Fatalf("WriteCurrentShows returned error: %v", err)
+	}
+	all, err := ReadAllShows()
+	if err != nil || len(all) != 3 {
+		t.Fatalf("expected three preserved shows, got %v %+v", err, all)
+	}
+	if all[0].Name != "Unwatched" || all[1].Name != "Rewatch" || all[2].Name != "Current" {
+		t.Fatalf("unexpected merged order/content: %+v", all)
 	}
 }
 

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -55,7 +55,7 @@ func GetAllFilms() ([]data.Film, error) {
 
 // GetAvailableGenres retrieves a list of unique genres from all shows
 func GetAvailableGenres() ([]string, error) {
-	s, err := db.ReadShows()
+	s, err := db.ReadAllShows()
 	if err != nil {
 		return nil, fmt.Errorf("GetAvailableGenres: error reading shows: %w", err)
 	}
@@ -65,7 +65,7 @@ func GetAvailableGenres() ([]string, error) {
 
 // GetUnwatchedShowsByGenre retrieves all unwatched shows for a given genre
 func GetUnwatchedShowsByGenre(genre string) ([]data.Show, error) {
-	s, err := db.ReadShows()
+	s, err := db.ReadUnwatchedShows()
 	if err != nil {
 		return nil, fmt.Errorf("GetUnwatchedShowsByGenre: error reading shows: %w", err)
 	}

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestGetCurrentlyWatchingShows(t *testing.T) {
 	dir := useTempDataDir(t)
-	writeFixture(t, dir, "currentShows.json", `[
+	writeFixture(t, dir, "shows.json", `[
   {
     "name": "Slow Horses",
     "genre": "Drama",
@@ -55,7 +55,7 @@ func TestGetCurrentlyWatchingShows(t *testing.T) {
 
 func TestMarkShowWatchedIncrementsAndPersistsEpisode(t *testing.T) {
 	dir := useTempDataDir(t)
-	writeFixture(t, dir, "currentShows.json", `[
+	writeFixture(t, dir, "shows.json", `[
   {
     "name": "Severance",
     "genre": "Sci-Fi",
@@ -88,7 +88,7 @@ func TestMarkShowWatchedIncrementsAndPersistsEpisode(t *testing.T) {
 
 func TestMarkShowWatchedCompletesAndPersistsShow(t *testing.T) {
 	dir := useTempDataDir(t)
-	writeFixture(t, dir, "currentShows.json", `[
+	writeFixture(t, dir, "shows.json", `[
   {
     "name": "One Episode Show",
     "genre": "Drama",
@@ -305,7 +305,7 @@ func writeFixture(t *testing.T, dir, name, content string) {
 func readCurrentShowsFixture(t *testing.T, dir string) []data.Show {
 	t.Helper()
 
-	raw, err := os.ReadFile(filepath.Join(dir, "currentShows.json"))
+	raw, err := os.ReadFile(filepath.Join(dir, "shows.json"))
 	if err != nil {
 		t.Fatalf("reading current shows fixture: %v", err)
 	}

--- a/plans/17-consolidate-show-data.md
+++ b/plans/17-consolidate-show-data.md
@@ -1,0 +1,122 @@
+# Issue #17: Consolidate show data into one file
+
+## Overview
+
+Replace the three show data files (`db/shows.json`, `db/currentShows.json`, and
+`db/rewatchShows.json`) with one canonical `db/shows.json` file. The file will
+store every show in one flat array, while the `db` package continues to expose
+focused functions that return only the requested category.
+
+The category is derived from fields on each `data.Show`: current-series and
+current-episode values identify currently watched shows, and a rewatch flag
+identifies rewatch entries. A show with neither status is unwatched.
+
+## Target data format
+
+Keep `db/shows.json` as a single JSON array, but add a rewatch marker to the
+`Show` type:
+
+```json
+[
+  {
+    "name": "Example",
+    "genre": "comedy",
+    "episodes": [6],
+    "provider": "BBC iPlayer",
+    "rewatch": true
+  }
+]
+```
+
+- Merge every existing entry from all three files into the array.
+- Add a `Rewatch bool` field to `data.Show` with the struct tag
+  `json:"rewatch,omitempty"`, setting it only on entries migrated from
+  `rewatchShows.json`.
+- Preserve `currentSeries` and `currentEpisode` on entries migrated from
+  `currentShows.json`; leave those pointers unset for unwatched and rewatch
+  entries unless the data explicitly requires both statuses.
+
+## Implementation steps
+
+### 1. Model the consolidated document
+
+- In `data/data.go`, add the `Rewatch` boolean field with an `omitempty` JSON
+  tag; keep `Show` as the single persisted record type.
+- Document the classification rule in code: current means both current-series
+  and current-episode are set, rewatch means `Rewatch == true`, and unwatched
+  means neither condition is true. Define precedence if a record has both
+  current pointers and the rewatch flag.
+
+### 2. Update database reads and writes
+
+- In `db/db.go`, add one private helper that reads and unmarshals the single
+  `shows.json` array. Retain the existing path
+  resolution behaviour, so a built binary can still use a data file beside the
+  executable and `go run` still falls back to `db/shows.json` in source.
+- Expose these distinct read functions, each returning `[]data.Show`:
+  - `ReadAllShows()` - returns the complete array.
+  - `ReadUnwatchedShows()` - filters records with neither current pointers nor
+    the rewatch flag.
+  - `ReadCurrentShows()` - filters records with the current pointers set.
+  - `ReadRewatchShows()` - filters records with `Rewatch == true`.
+- Replace the ambiguous existing `ReadShows()` call sites with
+  `ReadUnwatchedShows()` and remove `ReadShows()` once all in-repository callers
+  have migrated.
+- Change `WriteCurrentShows()` to read the complete array, replace the records
+  classified as currently watching with the supplied current records, and
+  atomically write the complete array back to `shows.json`. Preserve unwatched
+  and rewatch records. Define and test a stable matching key (for example,
+  name plus provider) for updates and additions because `Show` has no ID.
+- Factor the atomic JSON write into a private helper if it avoids duplication;
+  continue creating the temporary file in the target directory before rename.
+
+### 3. Migrate application callers
+
+- Update `handlers/handlers.go` so genre and unwatched-show operations call
+  `db.ReadUnwatchedShows()`; keep currently-watching operations on
+  `db.ReadCurrentShows()`.
+- Inspect CLI and HTTP layers for direct database access or terminology that
+  assumes separate JSON files, and update any affected tests or messages.
+- Do not add a user-facing rewatch feature as part of this issue; provide the
+  database reader so it is available to that future work.
+
+### 4. Migrate fixtures and tests
+
+- Update `db/db_test.go` fixtures to write one flat `shows.json` array and test
+  all four reader functions, including classification boundaries and complete
+  `ReadAllShows()` results.
+- Update missing-file and invalid-JSON table tests to exercise the consolidated
+  file through each reader.
+- Update write tests to verify `WriteCurrentShows()` replaces current records,
+  preserves unwatched and rewatch records, produces indented valid JSON,
+  replaces an existing file atomically, and cleans up its temporary file.
+- Update `handlers/handlers_test.go` fixtures to use the new JSON document;
+  retain coverage for marking an episode watched and verify it leaves
+  unwatched and rewatch records intact.
+
+### 5. Replace repository data and documentation
+
+- Build the new flat `db/shows.json` by merging the three current files and
+  setting `rewatch: true` on migrated rewatch entries, then remove
+  `db/currentShows.json` and
+  `db/rewatchShows.json` after the combined file has been verified.
+- Update `README.md` with the consolidated data-file format if it documents
+  show storage or deployment data files.
+- Update `AGENTS.md` to describe `db/shows.json` as the canonical show data
+  file and revise its database/path-resolution and write notes.
+- Update `copilot-instructions.md` only if it contains the old file names or
+  database workflow.
+
+## Acceptance criteria
+
+- `db/shows.json` is the only on-disk show data file; it is a flat array
+  containing every entry from the former files.
+- `ReadAllShows`, `ReadUnwatchedShows`, `ReadCurrentShows`, and
+  `ReadRewatchShows` each return exactly their documented data.
+- Marking a current episode persists the updated current records and does not
+  discard unwatched or rewatch data.
+- The CLI and HTTP behaviour for existing currently-watching and unwatched
+  flows remains unchanged.
+- Database and handler tests use only the consolidated file format and pass.
+- `go vet ./...`, `go build ./...`, `go test ./...`, and
+  `go test ./... -cover` succeed.

--- a/shows/shows.go
+++ b/shows/shows.go
@@ -108,7 +108,7 @@ func GetUniqueGenres(shows []data.Show) []string {
 func GetUnwatchedShowsByGenre(shows []data.Show, genre string) []data.Show {
 	var unwatched []data.Show
 	for _, s := range shows {
-		if s.Genre == genre && s.CurrentSeries == nil && s.CurrentEpisode == nil {
+		if s.Genre == genre && s.CurrentSeries == nil && s.CurrentEpisode == nil && !s.Rewatch {
 			unwatched = append(unwatched, s)
 		}
 	}


### PR DESCRIPTION
﻿## Summary

- Consolidate unwatched, currently watching, and rewatch shows into a single `db/shows.json` array.
- Infer show categories from current position fields and the new `rewatch` flag.
- Add distinct database readers and preserve non-current records when writing current-show updates.
- Migrate handlers, fixtures, tests, and repository documentation.

## Validation

- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `go test ./... -cover`
- All Go files pass `gofmt -l`.
